### PR TITLE
Add Stripe test page with server updates

### DIFF
--- a/test-page/server.py
+++ b/test-page/server.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """
-Simple HTTP server for testing PayPal payment integration
+Simple HTTP server for testing payment integrations (PayPal and Stripe)
 """
 
 import http.server
 import socketserver
 import webbrowser
 import os
-import sys
+import argparse
 
 PORT = 8000
 
@@ -18,37 +18,46 @@ class MyHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         self.send_header('Access-Control-Allow-Headers', 'Content-Type')
         super().end_headers()
 
-def start_server(use_switcher=False):
-    # Change to the test-page directory
+def start_server(page="paypal"):
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
-    
     with socketserver.TCPServer(("", PORT), MyHTTPRequestHandler) as httpd:
         print(f"🚀 Test server running at http://localhost:{PORT}")
-        
-        if use_switcher:
-            print(f"📝 Environment Switcher: http://localhost:{PORT}/index-switcher.html")
-            print(f"🔄 Switch between Sandbox and Live environments")
-            page_url = f'http://localhost:{PORT}/index-switcher.html'
+
+        if page == "switcher":
+            print(f"📝 PayPal Environment Switcher: http://localhost:{PORT}/index-switcher.html")
+            print("🔄 Switch between Sandbox and Live environments")
+            page_url = f"http://localhost:{PORT}/index-switcher.html"
+        elif page == "stripe":
+            print(f"📝 Stripe Test Page: http://localhost:{PORT}/stripe.html")
+            page_url = f"http://localhost:{PORT}/stripe.html"
         else:
-            print(f"📝 Basic Test Page: http://localhost:{PORT}/index.html")
-            print(f"🧪 Sandbox environment only")
-            page_url = f'http://localhost:{PORT}/index.html'
-        
-        print(f"⚠️  Make sure PayPal services are deployed to Cloudflare Workers")
-        print(f"🔧 Press Ctrl+C to stop the server")
-        print(f"")
-        print(f"Available pages:")
-        print(f"  • Basic Test (Sandbox): http://localhost:{PORT}/index.html")
-        print(f"  • Environment Switcher: http://localhost:{PORT}/index-switcher.html")
-        
-        # Auto-open browser
+            print(f"📝 PayPal Test Page: http://localhost:{PORT}/index.html")
+            page_url = f"http://localhost:{PORT}/index.html"
+
+        print("🔧 Press Ctrl+C to stop the server")
+        print("")
+        print("Available pages:")
+        print(f"  • PayPal Basic: http://localhost:{PORT}/index.html")
+        print(f"  • PayPal Switcher: http://localhost:{PORT}/index-switcher.html")
+        print(f"  • Stripe Test: http://localhost:{PORT}/stripe.html")
+
         webbrowser.open(page_url)
-        
+
         try:
             httpd.serve_forever()
         except KeyboardInterrupt:
             print("\n🛑 Server stopped")
 
 if __name__ == "__main__":
-    use_switcher = len(sys.argv) > 1 and sys.argv[1] == '--switcher'
-    start_server(use_switcher)
+    parser = argparse.ArgumentParser(description="Local test page server")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--switcher', action='store_true', help='Open PayPal environment switcher page')
+    group.add_argument('--stripe', action='store_true', help='Open Stripe test page')
+    args = parser.parse_args()
+
+    if args.switcher:
+        start_server("switcher")
+    elif args.stripe:
+        start_server("stripe")
+    else:
+        start_server("paypal")

--- a/test-page/stripe.html
+++ b/test-page/stripe.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stripe Payment Test</title>
+    <script src="https://js.stripe.com/v3/"></script>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            background: white;
+            padding: 30px;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #333;
+            text-align: center;
+        }
+        .product {
+            border: 1px solid #ddd;
+            padding: 20px;
+            margin: 20px 0;
+            border-radius: 5px;
+            background: #fafafa;
+        }
+        .product h3 {
+            margin-top: 0;
+            color: #635bff;
+        }
+        .price {
+            font-size: 24px;
+            font-weight: bold;
+            color: #333;
+            margin: 10px 0;
+        }
+        .input-group {
+            margin: 15px 0;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+        input {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            font-size: 16px;
+        }
+        button {
+            background: #635bff;
+            color: white;
+            padding: 15px 30px;
+            border: none;
+            border-radius: 5px;
+            font-size: 16px;
+            cursor: pointer;
+            width: 100%;
+            margin-top: 20px;
+        }
+        button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        .status {
+            padding: 15px;
+            margin: 20px 0;
+            border-radius: 5px;
+            display: none;
+        }
+        .status.success {
+            background: #d4edda;
+            color: #155724;
+            border: 1px solid #c3e6cb;
+        }
+        .status.error {
+            background: #f8d7da;
+            color: #721c24;
+            border: 1px solid #f5c6cb;
+        }
+        .status.info {
+            background: #d1ecf1;
+            color: #0c5460;
+            border: 1px solid #bee5eb;
+        }
+        .config {
+            background: #fff3cd;
+            padding: 15px;
+            border-radius: 5px;
+            border: 1px solid #ffeaa7;
+            margin-bottom: 20px;
+        }
+        .config code {
+            background: #f8f9fa;
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-family: 'Courier New', monospace;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Stripe Payment Test</h1>
+
+        <div class="config">
+            <h3>📋 Configuration</h3>
+            <p>Current API Endpoint: <code id="api-endpoint">https://stripe-payments-development.realharryscissors.workers.dev</code></p>
+            <p>Environment: <strong>Test</strong></p>
+            <p>Publishable Key: <code id="publishable-key">YOUR_STRIPE_PUBLISHABLE_KEY</code></p>
+        </div>
+
+        <div class="product">
+            <h3>🛍️ Test Product</h3>
+            <div class="price">$<span id="price">10.00</span></div>
+            <div class="input-group">
+                <label for="amount">Amount (USD):</label>
+                <input type="number" id="amount" value="10.00" min="1" step="0.01">
+            </div>
+            <div id="card-element" style="margin:20px 0;"></div>
+            <button id="pay-button">💳 Pay with Stripe</button>
+        </div>
+
+        <div id="status" class="status"></div>
+        <div id="payment-details" style="display:none;">
+            <h3>📄 Payment Details</h3>
+            <pre id="payment-json"></pre>
+        </div>
+    </div>
+
+    <script>
+        const API_BASE = 'https://stripe-payments-development.realharryscissors.workers.dev';
+        const stripe = Stripe('YOUR_STRIPE_PUBLISHABLE_KEY');
+        const elements = stripe.elements();
+        const cardElement = elements.create('card');
+        cardElement.mount('#card-element');
+
+        document.getElementById('pay-button').addEventListener('click', handlePayment);
+
+        function showStatus(message, type = 'info') {
+            const statusEl = document.getElementById('status');
+            statusEl.textContent = message;
+            statusEl.className = `status ${type}`;
+            statusEl.style.display = 'block';
+        }
+
+        async function handlePayment() {
+            const payButton = document.getElementById('pay-button');
+            const amount = document.getElementById('amount').value;
+            payButton.disabled = true;
+            showStatus('Creating payment intent...', 'info');
+            try {
+                const response = await fetch(`${API_BASE}/create-payment-intent`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ amount: parseFloat(amount) })
+                });
+                const data = await response.json();
+                if (!response.ok) {
+                    throw new Error(data.error || 'Failed to create payment intent');
+                }
+                const result = await stripe.confirmCardPayment(data.clientSecret, {
+                    payment_method: { card: cardElement }
+                });
+                if (result.error) {
+                    showStatus(result.error.message, 'error');
+                } else if (result.paymentIntent && result.paymentIntent.status === 'succeeded') {
+                    showStatus('Payment succeeded!', 'success');
+                    document.getElementById('payment-details').style.display = 'block';
+                    document.getElementById('payment-json').textContent = JSON.stringify(result.paymentIntent, null, 2);
+                }
+            } catch (err) {
+                showStatus(err.message, 'error');
+            } finally {
+                payButton.disabled = false;
+            }
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide a basic `stripe.html` page demonstrating payment intent creation and confirmation
- update the local test server so it can open PayPal, PayPal switcher, or Stripe pages via command-line options

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_686f3751229c83229118b66e5051c8fe